### PR TITLE
Implement service configuration option for WebDAV maximum upload file size

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -20,6 +20,7 @@ FILE="/var/www/html/config/config.php"
 
 DEFAULT_LOCALE=$(yq e '.default-locale' /root/start9/config.yaml)
 DEFAULT_PHONE_REGION=$(yq e '.default-phone-region' /root/start9/config.yaml)
+WEBDAV_UPLOAD_LIMIT=$((1048576 * $(yq e '.davfs-upload-limit' /root/start9/config.yaml)))
 
 if [ -e "$FILE" ] ; then
   NEXTCLOUD_ADMIN_PASSWORD=$(cat /root/start9/password.dat)
@@ -82,7 +83,7 @@ if [ -e "$FILE" ] ; then
   sed -i "/'dbtype' => 'pgsql',/a\\ \ 'overwriteprotocol' => 'https'\," $FILE
 
   until [ -e "/etc/apache2/sites-enabled/000-default.conf" ]; do { sleep 5; } done
-  sed -i 's/\#ServerName www\.example\.com.*/ServerName nextcloud.embassy\n        <IfModule mod_headers\.c>\n          Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"\n        <\/IfModule>/' /etc/apache2/sites-enabled/000-default.conf
+  sed -i "s/\#ServerName www\.example\.com.*/ServerName nextcloud.embassy\n        LimitRequestBody $WEBDAV_UPLOAD_LIMIT\n        <IfModule mod_headers\.c>\n          Header always set Strict-Transport-Security \"max-age=15552000; includeSubDomains\"\n        <\/IfModule>/" /etc/apache2/sites-enabled/000-default.conf
   sed -i "s/'overwrite\.cli\.url' => .*/'overwrite\.cli\.url' => 'https\:\/\/$LAN_ADDRESS'\,/" $FILE
 
   # Add default locale and phone region from user config and turn off update checker from UI

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -61,4 +61,14 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
     },
     "default": "US",
   },
+  "davfs-upload-limit": {
+    "name": "WebDAV maximum upload file size",
+    "description": "Maximum upload file size for webdav access",
+    "type": "number",
+    "units": "MiB (0 for unlimited)",
+    "nullable": false,
+    "integral": true,
+    "range": "[0,2047]",
+    "default": 1024
+  }
 });


### PR DESCRIPTION
In NextCloud v25.0.5, when accessing NextCloud shares through the WebDAV protocol, an apache configuration option  [LimitRequestBody](https://httpd.apache.org/docs/current/en/mod/core.html#limitrequestbody) limits the uploadable file size to a maximum of 1024MiBs . File uploads fail if the size exceeds this pre-set limit. For example when copying whole directories with a bunch of files, with large video files the uploads will fail.

Here is a solution for making LimitRequestBody configurable on the NextCloud service page with a custom configuration option.

Anyway, this could be useful for those who access the shared folders through WebDAV.

This is how this solution looks like on configuration page of NextCloud:
![image](https://github.com/Start9Labs/nextcloud-wrapper/assets/149899096/5935b242-c40e-4e8f-ab33-5dbf9d855239)
