### PR TITLE
Implement service configuration option for WebDAV maximum upload file with NextCloud 27.x

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -13,6 +13,9 @@ TRUSTED_PROXIES="$TOR_ADDRESS $LAN_ADDRESS $SERVICE_ADDRESS"
 FILE="/var/www/html/config/config.php"  
 PASSWORD_FILE="/root/start9/password.dat"
 INITIALIZED_FILE=/root/initialized
+WEBDAV_MAX_UPLOAD_FILE_SIZE_LIMIT=$(yq e '.webdav.max-upload-file-size-limit' /root/start9/config.yaml)
+
+sed -i "s/client_max_body_size\ 1024M/client_max_body_size\ $WEBDAV_MAX_UPLOAD_FILE_SIZE_LIMIT$([[ "$WEBDAV_MAX_UPLOAD_FILE_SIZE_LIMIT" == "0" ]] && echo "" || echo "M")/g" /etc/nginx/http.d/default.conf
 
 if ! [ -f $INITIALIZED_FILE ]; then
   echo "Performing initialization..."

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -61,4 +61,21 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
     },
     "default": "US",
   },
+  "webdav": {
+    "type": "object",
+    "name": "WebDAV settings",
+    "description": "WebDAV configuration options.",
+    "spec": {
+      "max-upload-file-size-limit": {
+        "name": "Maximum upload file size",
+        "description": "Maximum upload file size for webdav access (set to 0 for an unlimited upload size)",
+        "type": "number",
+        "units": "MiB (0 for unlimited)",
+        "nullable": false,
+        "integral": true,
+        "range": "[0,2048]",
+        "default": 1024
+      }
+    }
+  }
 });


### PR DESCRIPTION
This is the continuation of #51. Checked it again and the same thing happens with nginx, it also has the same default 1G of maximum upload size limitation through webdav. 

Just to reiterate this happens when mounting a webdav directory through the command line and trying to copy a file over which is bigger than the limit. With this fix, there will be a new config option before starting the service for setting this upload limit size. Special option is setting it to 0 because that removes any upload size limitation, theoretically any file with any size could be uploaded, if it fits into the quota size of the NextCloud share into it is being uploaded.

Might be just an edge case but it still could be useful to be able to configure this.