### PR TITLE
increase timeout to allow setup check to pass

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -164,6 +164,9 @@ server {
         fastcgi_request_buffering off;
 
         fastcgi_max_temp_file_size 0;
+
+        fastcgi_send_timeout 120s;
+        fastcgi_read_timeout 120s;
     }
 
     # Serve static files


### PR DESCRIPTION
I noticed the "Security & setup warnings" check never passed on my install due to a timeout from the server. It seems others have had this issue with Nextcloud. I found [a simple fix](https://help.nextcloud.com/t/error-occurred-while-checking-server-setup-but-there-are-not/160760/2) to just extend the timeout to give it time to finish.